### PR TITLE
Removed hardcoded test file path and replace it with actual reference from inside test. This allows the reference of alternate test files.

### DIFF
--- a/.github/actions/templates/avm-validateModulePester/action.yml
+++ b/.github/actions/templates/avm-validateModulePester/action.yml
@@ -84,7 +84,7 @@ runs:
         }
 
         Write-Verbose 'Invoke test with' -Verbose
-        Write-Verbose ($pesterConfiguration | ConvertTo-Json -Depth 5 | Out-String) -Verbose
+        Write-Verbose ($pesterConfiguration | ConvertTo-Json -Depth 2 | Out-String) -Verbose
 
         $testResults = Invoke-Pester -Configuration $pesterConfiguration
 

--- a/.github/actions/templates/avm-validateModulePester/action.yml
+++ b/.github/actions/templates/avm-validateModulePester/action.yml
@@ -53,42 +53,28 @@ runs:
         # Set test input module path
         $moduleFolderPaths = @(Join-Path $repoRootPath "${{ inputs.modulePath }}")
         $moduleFolderPaths += (Get-ChildItem $moduleFolderPaths -Recurse -Directory -Force).FullName | Where-Object {
-                  (Get-ChildItem $_ -File -Depth 0 -Include @('main.json', 'main.bicep') -Force).Count -gt 0
+          (Get-ChildItem $_ -File -Depth 0 -Include @('main.json', 'main.bicep') -Force).Count -gt 0
         }
         Write-Verbose 'Execute tests in path(s):' -Verbose
         foreach ($moduleFolderPath in $moduleFolderPaths) {
           Write-Verbose "- [($moduleFolderPath]" -Verbose
         }
-        # TODO: remove token replacement if not needed
-        # # Construct Token Configuration Input and enforced tokens list
-        # $GlobalVariablesObject = Get-Content -Path 'settings.yml' | ConvertFrom-Yaml | Select-Object -ExpandProperty variables
-        # $tokenConfiguration = @{
-        #   Tokens      = @{}
-        #   TokenPrefix = $GlobalVariablesObject | Select-Object -ExpandProperty tokenPrefix
-        #   TokenSuffix = $GlobalVariablesObject | Select-Object -ExpandProperty tokenSuffix
-        # }
 
-        # if (-not [String]::IsNullOrEmpty('${{ env.ARM_SUBSCRIPTION_ID }}')) {
-        #   $tokenConfiguration.Tokens['subscriptionId'] = '${{ env.ARM_SUBSCRIPTION_ID }}'
-        # }
-        # if (-not [String]::IsNullOrEmpty('${{ env.ARM_MGMTGROUP_ID }}')) {
-        #   $tokenConfiguration.Tokens['managementGroupId'] = '${{ env.ARM_MGMTGROUP_ID }}'
-        # }
-        # if (-not [String]::IsNullOrEmpty('${{ env.ARM_TENANT_ID }}')) {
-        #   $tokenConfiguration.Tokens['tenantId'] = '${{ env.ARM_TENANT_ID }}'
-        # }
 
         $moduleTestFilePath = '${{ inputs.moduleTestFilePath }}'
 
         # --------------------- #
         # Invoke Pester test(s) #
         # --------------------- #
+        $testFiles = @(
+          (Join-Path $repoRootPath $moduleTestFilePath),        # AVM Compliance Tests
+          (Join-Path "${{ inputs.modulePath }}" 'tests' 'unit') # Custom Unit Tests
+        )
+
         $pesterConfiguration = @{
           Run    = @{
-            Container = New-PesterContainer -Path (Join-Path $repoRootPath $moduleTestFilePath) -Data @{
+            Container = New-PesterContainer -Path $testFiles -Data @{
               moduleFolderPaths                = $moduleFolderPaths
-              # tokenConfiguration             = $tokenConfiguration
-              # allowPreviewVersionsInAPITests = [System.Convert]::ToBoolean('${{ env.allowPreviewVersionsInAPITests }}')
             }
             PassThru  = $true
           }

--- a/.github/actions/templates/avm-validateModulePester/action.yml
+++ b/.github/actions/templates/avm-validateModulePester/action.yml
@@ -57,24 +57,21 @@ runs:
         }
         Write-Verbose 'Execute tests in path(s):' -Verbose
         foreach ($moduleFolderPath in $moduleFolderPaths) {
-          Write-Verbose "- [($moduleFolderPath]" -Verbose
+          Write-Verbose "- [$moduleFolderPath]" -Verbose
         }
-
-
-        $moduleTestFilePath = '${{ inputs.moduleTestFilePath }}'
 
         # --------------------- #
         # Invoke Pester test(s) #
         # --------------------- #
         $testFiles = @(
-          (Join-Path $repoRootPath $moduleTestFilePath),        # AVM Compliance Tests
-          (Join-Path "${{ inputs.modulePath }}" 'tests' 'unit') # Custom Unit Tests
+          (Join-Path $repoRootPath '${{ inputs.moduleTestFilePath }}'), # AVM Compliance Tests
+          (Join-Path "${{ inputs.modulePath }}" 'tests' 'unit')         # Custom Unit Tests
         )
 
         $pesterConfiguration = @{
           Run    = @{
             Container = New-PesterContainer -Path $testFiles -Data @{
-              moduleFolderPaths                = $moduleFolderPaths
+              moduleFolderPaths = $moduleFolderPaths
             }
             PassThru  = $true
           }

--- a/.github/actions/templates/avm-validateModulePester/action.yml
+++ b/.github/actions/templates/avm-validateModulePester/action.yml
@@ -81,7 +81,7 @@ runs:
         }
 
         Write-Verbose 'Invoke test with' -Verbose
-        Write-Verbose ($pesterConfiguration | ConvertTo-Json -Depth 2 | Out-String) -Verbose
+        Write-Verbose ($pesterConfiguration | ConvertTo-Json -Depth 4 | Out-String) -Verbose
 
         $testResults = Invoke-Pester -Configuration $pesterConfiguration
 

--- a/.github/workflows/avm.res.cognitive-services.account.yml
+++ b/.github/workflows/avm.res.cognitive-services.account.yml
@@ -34,7 +34,7 @@ on:
   #     - '!*/**/README.md'
 
 env:
-  modulePath: 'avm-res/cognitive-services/account'
+  modulePath: 'avm/res/cognitive-services/account'
   workflowPath: '.github/workflows/avm.res.cognitive-services.account.yml'
 
 concurrency:

--- a/avm/res/cognitive-services/account/tests/unit/custom.tests.ps1
+++ b/avm/res/cognitive-services/account/tests/unit/custom.tests.ps1
@@ -1,10 +1,7 @@
-Describe "Custom Test" {
-
-    It "Should pass" {
-        $true | Should -Be $true
-    }
-
-    It "Should fail" {
-        $false | Should -Be $true
-    }
-}
+#############################
+## Addition unit tests     ##
+#############################
+##
+## You can add any custom static validation tests you want here, or add them spread accross multple test files in the unit folder.
+##
+#############################

--- a/avm/res/cognitive-services/account/tests/unit/custom.tests.ps1
+++ b/avm/res/cognitive-services/account/tests/unit/custom.tests.ps1
@@ -5,6 +5,6 @@ Describe "Custom Test" {
     }
 
     It "Should fail" {
-        $true | Should -Be $true
+        $false | Should -Be $true
     }
 }

--- a/avm/res/cognitive-services/account/tests/unit/custom.tests.ps1
+++ b/avm/res/cognitive-services/account/tests/unit/custom.tests.ps1
@@ -1,0 +1,10 @@
+Describe "Custom Test" {
+
+    It "Should pass" {
+        $true | Should -Be $true
+    }
+
+    It "Should fail" {
+        $true | Should -Be $true
+    }
+}

--- a/avm/res/key-vault/vault/tests/unit/custom.tests.ps1
+++ b/avm/res/key-vault/vault/tests/unit/custom.tests.ps1
@@ -1,0 +1,13 @@
+#############################
+## Addition unit tests     ##
+#############################
+##
+## You can add any custom static validation tests you want here, or add them spread accross multple test files in the unit folder.
+##
+##########################################################
+## Addition unit tests     ##
+#############################
+##
+## You can add any custom static validation tests you want here, or add them spread accross multple test files in the unit folder.
+##
+#############################

--- a/avm/res/network/private-endpoint/tests/unit/custom.tests.ps1
+++ b/avm/res/network/private-endpoint/tests/unit/custom.tests.ps1
@@ -1,0 +1,13 @@
+#############################
+## Addition unit tests     ##
+#############################
+##
+## You can add any custom static validation tests you want here, or add them spread accross multple test files in the unit folder.
+##
+##########################################################
+## Addition unit tests     ##
+#############################
+##
+## You can add any custom static validation tests you want here, or add them spread accross multple test files in the unit folder.
+##
+#############################

--- a/avm/utilities/pipelines/publish/Publish-ModuleFromPathToPBR.ps1
+++ b/avm/utilities/pipelines/publish/Publish-ModuleFromPathToPBR.ps1
@@ -18,7 +18,6 @@ function Publish-ModuleFromPathToPBR {
   . (Join-Path $PSScriptRoot '..' 'sharedScripts' 'tokenReplacement' 'Convert-TokensInFileList.ps1')
 
   $moduleFolderPath = Split-Path $TemplateFilePath -Parent
-
   $moduleJsonFilePath = Join-Path $moduleFolderPath 'main.json'
 
   # 1. Test if module qualifies for publishing

--- a/avm/utilities/pipelines/publish/Publish-ModuleFromPathToPBR.ps1
+++ b/avm/utilities/pipelines/publish/Publish-ModuleFromPathToPBR.ps1
@@ -18,11 +18,8 @@ function Publish-ModuleFromPathToPBR {
   . (Join-Path $PSScriptRoot '..' 'sharedScripts' 'tokenReplacement' 'Convert-TokensInFileList.ps1')
 
   $moduleFolderPath = Split-Path $TemplateFilePath -Parent
-  # TODO remove next write verbose
-  Write-Verbose "moduleFolderPath $moduleFolderPath" -Verbose
+
   $moduleJsonFilePath = Join-Path $moduleFolderPath 'main.json'
-
-
 
   # 1. Test if module qualifies for publishing
   if (-not (Get-ModulesToPublish -ModuleFolderPath $moduleFolderPath)) {

--- a/avm/utilities/pipelines/staticValidation/compliance/Set-PesterGitHubOutput.ps1
+++ b/avm/utilities/pipelines/staticValidation/compliance/Set-PesterGitHubOutput.ps1
@@ -129,7 +129,6 @@ function Set-PesterGitHubOutput {
 
       $errorTestLine = $failedTest.ErrorRecord.TargetObject.Line
       $errorTestFile = (($failedTest.ErrorRecord.TargetObject.File -split '[\/|\\](avm[\/|\\])')[-2, -1] -join '') -replace '\\', '/' # e.g., [avm\res\cognitive-services\account\tests\unit\custom.tests.ps1]
-
       $errorMessage = $failedTest.ErrorRecord.TargetObject.Message.Trim() -replace '\n', '<br>' # Replace new lines with <br> to enable line breaks in markdown
 
       $testReference = '{0}:{1}' -f $errorTestFile, $errorTestLine
@@ -137,7 +136,6 @@ function Set-PesterGitHubOutput {
       if (-not [String]::IsNullOrEmpty($GitHubRepository) -and -not [String]::IsNullOrEmpty($BranchName)) {
         # Creating URL to test file to enable users to 'click' on it
         $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/$errorTestFile#L$errorTestLine)"
-
       }
 
       $fileContent += '| {0} | {1} | <code>{2}</code> |' -f $testName, $errorMessage, $testReference

--- a/avm/utilities/pipelines/staticValidation/compliance/Set-PesterGitHubOutput.ps1
+++ b/avm/utilities/pipelines/staticValidation/compliance/Set-PesterGitHubOutput.ps1
@@ -128,7 +128,7 @@ function Set-PesterGitHubOutput {
       $testName = (($intermediateNameElements -join ' / ' | Out-String) -replace '\|', '\|').Trim()
 
       $errorTestLine = $failedTest.ErrorRecord.TargetObject.Line
-      $errorTestFile = (Split-Path $failedTest.ErrorRecord.TargetObject.File -Leaf).Trim()
+      $errorTestFile = (($failedTest.ErrorRecord.TargetObject.File -split '[\/|\\](avm[\/|\\])')[-2, -1] -join '') -replace '\\', '/' # e.g., [avm\res\cognitive-services\account\tests\unit\custom.tests.ps1]
 
       $errorMessage = $failedTest.ErrorRecord.TargetObject.Message.Trim() -replace '\n', '<br>' # Replace new lines with <br> to enable line breaks in markdown
 
@@ -136,7 +136,7 @@ function Set-PesterGitHubOutput {
 
       if (-not [String]::IsNullOrEmpty($GitHubRepository) -and -not [String]::IsNullOrEmpty($BranchName)) {
         # Creating URL to test file to enable users to 'click' on it
-        $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/avm/utilities/pipelines/staticValidation/module.tests.ps1#L$errorTestLine)"
+        $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/$errorTestFile#L$errorTestLine)"
 
       }
 
@@ -177,7 +177,7 @@ function Set-PesterGitHubOutput {
       $testName = (($intermediateNameElements -join ' / ' | Out-String) -replace '\|', '\|').Trim()
 
       $testLine = $passedTest.ScriptBlock.StartPosition.StartLine
-      $testFile = (Split-Path $passedTest.ScriptBlock.File -Leaf).Trim()
+      $testFile = (($passedTest.ScriptBlock.File -split '[\/|\\](avm[\/|\\])')[-2, -1] -join '') -replace '\\', '/' # e.g., [avm\res\cognitive-services\account\tests\unit\custom.tests.ps1]
 
       $testReference = '{0}:{1}' -f $testFile, $testLine
       if (-not [String]::IsNullOrEmpty($GitHubRepository) -and -not [String]::IsNullOrEmpty($BranchName)) {
@@ -225,7 +225,7 @@ function Set-PesterGitHubOutput {
       $reason = ('Test {0}' -f $skippedTest.ErrorRecord.Exception.Message -replace '\|', '\|').Trim()
 
       $testLine = $passedTest.ScriptBlock.StartPosition.StartLine
-      $testFile = (Split-Path $passedTest.ScriptBlock.File -Leaf).Trim()
+      $testFile = (($passedTest.ScriptBlock.File -split '[\/|\\](avm[\/|\\])')[-2, -1] -join '') -replace '\\', '/' # e.g., [avm\res\cognitive-services\account\tests\unit\custom.tests.ps1]
 
       $testReference = '{0}:{1}' -f $testFile, $testLine
       if (-not [String]::IsNullOrEmpty($GitHubRepository) -and -not [String]::IsNullOrEmpty($BranchName)) {

--- a/avm/utilities/pipelines/staticValidation/compliance/Set-PesterGitHubOutput.ps1
+++ b/avm/utilities/pipelines/staticValidation/compliance/Set-PesterGitHubOutput.ps1
@@ -182,7 +182,7 @@ function Set-PesterGitHubOutput {
       $testReference = '{0}:{1}' -f $testFile, $testLine
       if (-not [String]::IsNullOrEmpty($GitHubRepository) -and -not [String]::IsNullOrEmpty($BranchName)) {
         # Creating URL to test file to enable users to 'click' on it
-        $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/utilities/pipelines/staticValidation/module.tests.ps1#L$testLine)"
+        $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/$testFile#L$testLine)"
       }
 
       $fileContent += '| {0} | <code>{1}</code> |' -f $testName, $testReference
@@ -230,7 +230,7 @@ function Set-PesterGitHubOutput {
       $testReference = '{0}:{1}' -f $testFile, $testLine
       if (-not [String]::IsNullOrEmpty($GitHubRepository) -and -not [String]::IsNullOrEmpty($BranchName)) {
         # Creating URL to test file to enable users to 'click' on it
-        $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/utilities/pipelines/staticValidation/module.tests.ps1#L$testLine)"
+        $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/$testFile#L$testLine)"
       }
 
       $fileContent += '| {0} | {1} | <code>{2}</code> |' -f $testName, $reason, $testReference

--- a/avm/utilities/pipelines/staticValidation/compliance/Set-PesterGitHubOutput.ps1
+++ b/avm/utilities/pipelines/staticValidation/compliance/Set-PesterGitHubOutput.ps1
@@ -131,7 +131,7 @@ function Set-PesterGitHubOutput {
       $errorTestFile = (($failedTest.ErrorRecord.TargetObject.File -split '[\/|\\](avm[\/|\\])')[-2, -1] -join '') -replace '\\', '/' # e.g., [avm\res\cognitive-services\account\tests\unit\custom.tests.ps1]
       $errorMessage = $failedTest.ErrorRecord.TargetObject.Message.Trim() -replace '\n', '<br>' # Replace new lines with <br> to enable line breaks in markdown
 
-      $testReference = '{0}:{1}' -f $errorTestFile, $errorTestLine
+      $testReference = '{0}:{1}' -f (Split-Path $errorTestFile -Leaf), $errorTestLine
 
       if (-not [String]::IsNullOrEmpty($GitHubRepository) -and -not [String]::IsNullOrEmpty($BranchName)) {
         # Creating URL to test file to enable users to 'click' on it
@@ -177,7 +177,7 @@ function Set-PesterGitHubOutput {
       $testLine = $passedTest.ScriptBlock.StartPosition.StartLine
       $testFile = (($passedTest.ScriptBlock.File -split '[\/|\\](avm[\/|\\])')[-2, -1] -join '') -replace '\\', '/' # e.g., [avm\res\cognitive-services\account\tests\unit\custom.tests.ps1]
 
-      $testReference = '{0}:{1}' -f $testFile, $testLine
+      $testReference = '{0}:{1}' -f (Split-Path $testFile -Leaf), $testLine
       if (-not [String]::IsNullOrEmpty($GitHubRepository) -and -not [String]::IsNullOrEmpty($BranchName)) {
         # Creating URL to test file to enable users to 'click' on it
         $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/$testFile#L$testLine)"
@@ -225,7 +225,7 @@ function Set-PesterGitHubOutput {
       $testLine = $passedTest.ScriptBlock.StartPosition.StartLine
       $testFile = (($passedTest.ScriptBlock.File -split '[\/|\\](avm[\/|\\])')[-2, -1] -join '') -replace '\\', '/' # e.g., [avm\res\cognitive-services\account\tests\unit\custom.tests.ps1]
 
-      $testReference = '{0}:{1}' -f $testFile, $testLine
+      $testReference = '{0}:{1}' -f (Split-Path $testFile -Leaf), $testLine
       if (-not [String]::IsNullOrEmpty($GitHubRepository) -and -not [String]::IsNullOrEmpty($BranchName)) {
         # Creating URL to test file to enable users to 'click' on it
         $testReference = "[$testReference](https://github.com/$GitHubRepository/blob/$BranchName/$testFile#L$testLine)"

--- a/avm/utilities/tools/Test-ModuleLocally.ps1
+++ b/avm/utilities/tools/Test-ModuleLocally.ps1
@@ -218,9 +218,14 @@ function Test-ModuleLocally {
             }
 
             try {
+                $testFiles = @(
+                    (Join-Path $repoRootPath $PesterTestFilePath), # AVM Compliance Tests
+                    (Join-Path $moduleRoot 'tests' 'unit')         # Module Unit Tests
+                )
+
                 Invoke-Pester -Configuration @{
                     Run    = @{
-                        Container = New-PesterContainer -Path (Join-Path $repoRootPath $PesterTestFilePath) -Data @{
+                        Container = New-PesterContainer -Path $testFiles -Data @{
                             repoRootPath       = $repoRootPath
                             moduleFolderPaths  = Split-Path $TemplateFilePath -Parent
                             tokenConfiguration = $PesterTokenConfiguration


### PR DESCRIPTION
Removed hardcoded test file path and replace it with actual reference from inside test. This allows the reference of alternate test files.

![image](https://github.com/eriqua/bicep-registry-modules/assets/5365358/84593c35-7d5c-4cbf-a49c-e2ca1dc08ecd)
