### PR TITLE
[CI Environment] Updated file resolution to recursive approach

### DIFF
--- a/.github/actions/templates/avm-validateModuleDeployment/action.yml
+++ b/.github/actions/templates/avm-validateModuleDeployment/action.yml
@@ -69,6 +69,7 @@ runs:
 
           # Load used functions
           . (Join-Path $env:GITHUB_WORKSPACE 'avm' 'utilities' 'pipelines' 'sharedScripts' 'tokenReplacement' 'Convert-TokensInFileList.ps1')
+          . (Join-Path $env:GITHUB_WORKSPACE 'avm' 'utilities' 'pipelines' 'sharedScripts' 'Get-LocallyReferencedFileList.ps1')
 
           $templateFilePath = Join-Path $env:GITHUB_WORKSPACE '${{ inputs.templateFilePath }}'
 
@@ -77,15 +78,9 @@ runs:
             $templateFilePath
           )
 
-          # Add all module template files as they contain a version statement
-          if($templateFilePath -match '.*[\/|\\]tests[\/|\\].*') {
-            # e.g. (...)/cognitive-services/account/tests/e2e/defauts/main.test.bicep
-            $moduleRoot = (Get-Item (Split-Path $templateFilePath)).Parent.Parent.Parent.FullName
-          } else {
-            # e.g. (...)/cognitive-services/account/main.bicep
-            $moduleRoot = Split-Path $templateFilePath
-          }
-          $targetFileList += (Get-ChildItem -Path $moduleRoot -Recurse -File).FullName | Where-Object { $_ -match '.+(main.json|main.bicep)$' }
+          # Add all module template files as they may contain tokens
+          $targetFileList += (Get-LocallyReferencedFileList -FilePath $templateFilePath)
+          $targetFileList = $targetFileList | Sort-Object -Unique
 
           # Construct Token Function Input
           $ConvertTokensInputs = @{

--- a/avm/res/cognitive-services/account/README.md
+++ b/avm/res/cognitive-services/account/README.md
@@ -113,7 +113,7 @@ module account 'br/public:avm-res-cognitiveservices-account:1.0.0' = {
     kind: 'Face'
     name: 'csamax001'
     // Non-required parameters
-    customSubDomainName: 'xdomain'
+    customSubDomainName: 'xcsamax'
     diagnosticSettings: [
       {
         eventHubAuthorizationRuleResourceId: '<eventHubAuthorizationRuleResourceId>'
@@ -219,7 +219,7 @@ module account 'br/public:avm-res-cognitiveservices-account:1.0.0' = {
     },
     // Non-required parameters
     "customSubDomainName": {
-      "value": "xdomain"
+      "value": "xcsamax"
     },
     "diagnosticSettings": {
       "value": [
@@ -617,7 +617,7 @@ module account 'br/public:avm-res-cognitiveservices-account:1.0.0' = {
     kind: 'Face'
     name: 'csawaf001'
     // Non-required parameters
-    customSubDomainName: 'xdomain'
+    customSubDomainName: 'xcsawaf'
     diagnosticSettings: [
       {
         eventHubAuthorizationRuleResourceId: '<eventHubAuthorizationRuleResourceId>'
@@ -723,7 +723,7 @@ module account 'br/public:avm-res-cognitiveservices-account:1.0.0' = {
     },
     // Non-required parameters
     "customSubDomainName": {
-      "value": "xdomain"
+      "value": "xcsawaf"
     },
     "diagnosticSettings": {
       "value": [

--- a/avm/res/cognitive-services/account/README.md
+++ b/avm/res/cognitive-services/account/README.md
@@ -1444,4 +1444,8 @@ The storage accounts for this resource.
 
 ## Cross-referenced modules
 
-_None_
+This section gives you an overview of all local-referenced module files (i.e., other CARML modules that are referenced in this module) and all remote-referenced files (i.e., Bicep modules that are referenced from a Bicep Registry or Template Specs).
+
+| Reference | Type |
+| :-- | :-- |
+| `res/network/private-endpoint` | Local reference |

--- a/avm/res/cognitive-services/account/tests/e2e/max/main.test.bicep
+++ b/avm/res/cognitive-services/account/tests/e2e/max/main.test.bicep
@@ -62,7 +62,7 @@ module testDeployment '../../../main.bicep' = {
   params: {
     name: '${namePrefix}${serviceShort}001'
     kind: 'Face'
-    customSubDomainName: '${namePrefix}xdomain'
+    customSubDomainName: '${namePrefix}x${serviceShort}'
     location: location
     diagnosticSettings: [
       {

--- a/avm/res/cognitive-services/account/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/cognitive-services/account/tests/e2e/waf-aligned/main.test.bicep
@@ -63,7 +63,7 @@ module testDeployment '../../../main.bicep' = {
     name: '${namePrefix}${serviceShort}001'
     kind: 'Face'
     location: location
-    customSubDomainName: '${namePrefix}xdomain'
+    customSubDomainName: '${namePrefix}x${serviceShort}'
     diagnosticSettings: [
       {
         name: 'customSetting'

--- a/avm/res/key-vault/vault/README.md
+++ b/avm/res/key-vault/vault/README.md
@@ -1532,4 +1532,8 @@ Resource tags.
 
 ## Cross-referenced modules
 
-_None_
+This section gives you an overview of all local-referenced module files (i.e., other CARML modules that are referenced in this module) and all remote-referenced files (i.e., Bicep modules that are referenced from a Bicep Registry or Template Specs).
+
+| Reference | Type |
+| :-- | :-- |
+| `res/network/private-endpoint` | Local reference |

--- a/avm/utilities/pipelines/sharedScripts/Get-LocallyReferencedFileList.ps1
+++ b/avm/utilities/pipelines/sharedScripts/Get-LocallyReferencedFileList.ps1
@@ -1,0 +1,38 @@
+<#
+.SYNOPSIS
+Get all bicep files involved in a module deployment as per their local references (recusively)
+
+.DESCRIPTION
+Get all bicep files involved in a module deployment as per their local references (recusively).
+That means if module A references module B, which references module C, then all three module paths are returned.
+
+.PARAMETER FilePath
+Mandatory. The path to the template to investigate.
+
+.EXAMPLE
+Get-LocallyReferencedFileList -FilePath 'C:/modules/key-vault/vault/main.bicep'
+
+Get all referenced paths of file 'C:/modules/key-vault/vault/main.bicep'
+#>
+function Get-LocallyReferencedFileList {
+
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [string] $FilePath
+    )
+
+    $resList = @()
+
+    $fileContent = Get-Content $FilePath
+
+    $resList += $fileContent | Where-Object { $_ -match "^module .+ '(.+.bicep)' .+$" } | ForEach-Object { (Resolve-Path (Join-Path (Split-Path $FilePath) $matches[1])).Path }
+
+    if ($resList.Count -gt 0) {
+        foreach ($containedFilePath in $resList) {
+            $resList += Get-LocallyReferencedFileList -FilePath $containedFilePath
+        }
+    }
+
+    return $resList
+}


### PR DESCRIPTION
## Description

- Updated file resolution to recursive approach (that also works with local paths)
- Applied the same logic to CARML (ref: https://github.com/Azure/ResourceModules/pull/4026)
- Refreshed all readmes

Affect on token replacement (file selection). Example `key-vault/vault`
![image](https://github.com/eriqua/bicep-registry-modules/assets/5365358/c847124c-8ce7-414a-817a-191b5af6d5d0)
