### PR TITLE
[Modules] Adjusted PSRule Workaround values to use `null` instead of an empty value

### DIFF
--- a/avm/res/key-vault/vault/README.md
+++ b/avm/res/key-vault/vault/README.md
@@ -56,16 +56,16 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
     // Required parameters
     name: 'kvvd002'
     // Non-required parameters
-    accessPolicies: []
-    diagnosticSettings: []
+    accessPolicies: '<accessPolicies>'
+    diagnosticSettings: '<diagnosticSettings>'
     enablePurgeProtection: false
-    keys: []
+    keys: '<keys>'
     location: '<location>'
-    lock: {}
-    privateEndpoints: []
-    roleAssignments: []
-    secrets: {}
-    tags: {}
+    lock: '<lock>'
+    privateEndpoints: '<privateEndpoints>'
+    roleAssignments: '<roleAssignments>'
+    secrets: '<secrets>'
+    tags: '<tags>'
   }
 }
 ```
@@ -86,34 +86,34 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
       "value": "kvvd002"
     },
     "accessPolicies": {
-      "value": []
+      "value": "<accessPolicies>"
     },
     "diagnosticSettings": {
-      "value": []
+      "value": "<diagnosticSettings>"
     },
     "enablePurgeProtection": {
       "value": false
     },
     "keys": {
-      "value": []
+      "value": "<keys>"
     },
     "location": {
       "value": "<location>"
     },
     "lock": {
-      "value": {}
+      "value": "<lock>"
     },
     "privateEndpoints": {
-      "value": []
+      "value": "<privateEndpoints>"
     },
     "roleAssignments": {
-      "value": []
+      "value": "<roleAssignments>"
     },
     "secrets": {
-      "value": {}
+      "value": "<secrets>"
     },
     "tags": {
-      "value": {}
+      "value": "<tags>"
     }
   }
 }
@@ -634,7 +634,7 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
     // Required parameters
     name: 'kvvwaf002'
     // Non-required parameters
-    accessPolicies: []
+    accessPolicies: '<accessPolicies>'
     diagnosticSettings: [
       {
         eventHubAuthorizationRuleResourceId: '<eventHubAuthorizationRuleResourceId>'
@@ -694,7 +694,7 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
         subnetResourceId: '<subnetResourceId>'
       }
     ]
-    roleAssignments: []
+    roleAssignments: '<roleAssignments>'
     secrets: {
       secureList: [
         {
@@ -732,7 +732,7 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
       "value": "kvvwaf002"
     },
     "accessPolicies": {
-      "value": []
+      "value": "<accessPolicies>"
     },
     "diagnosticSettings": {
       "value": [
@@ -810,7 +810,7 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
       ]
     },
     "roleAssignments": {
-      "value": []
+      "value": "<roleAssignments>"
     },
     "secrets": {
       "value": {

--- a/avm/res/key-vault/vault/README.md
+++ b/avm/res/key-vault/vault/README.md
@@ -62,6 +62,7 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
     keys: '<keys>'
     location: '<location>'
     lock: '<lock>'
+    networkAcls: '<networkAcls>'
     privateEndpoints: '<privateEndpoints>'
     roleAssignments: '<roleAssignments>'
     secrets: '<secrets>'
@@ -102,6 +103,9 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
     },
     "lock": {
       "value": "<lock>"
+    },
+    "networkAcls": {
+      "value": "<networkAcls>"
     },
     "privateEndpoints": {
       "value": "<privateEndpoints>"
@@ -542,8 +546,13 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
     // Required parameters
     name: 'kvvpe001'
     // Non-required parameters
+    accessPolicies: '<accessPolicies>'
+    diagnosticSettings: '<diagnosticSettings>'
     enablePurgeProtection: false
+    keys: '<keys>'
     location: '<location>'
+    lock: '<lock>'
+    networkAcls: '<networkAcls>'
     privateEndpoints: [
       {
         privateDnsZoneResourceIds: [
@@ -557,6 +566,8 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
         }
       }
     ]
+    roleAssignments: '<roleAssignments>'
+    secrets: '<secrets>'
     tags: {
       Environment: 'Non-Prod'
       'hidden-title': 'This is visible in the resource name'
@@ -578,16 +589,29 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
   "$schema": "https://schema.management.azure.com/schemas/2019-04-01/deploymentParameters.json#",
   "contentVersion": "1.0.0.0",
   "parameters": {
-    // Required parameters
     "name": {
       "value": "kvvpe001"
     },
-    // Non-required parameters
+    "accessPolicies": {
+      "value": "<accessPolicies>"
+    },
+    "diagnosticSettings": {
+      "value": "<diagnosticSettings>"
+    },
     "enablePurgeProtection": {
       "value": false
     },
+    "keys": {
+      "value": "<keys>"
+    },
     "location": {
       "value": "<location>"
+    },
+    "lock": {
+      "value": "<lock>"
+    },
+    "networkAcls": {
+      "value": "<networkAcls>"
     },
     "privateEndpoints": {
       "value": [
@@ -603,6 +627,12 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
           }
         }
       ]
+    },
+    "roleAssignments": {
+      "value": "<roleAssignments>"
+    },
+    "secrets": {
+      "value": "<secrets>"
     },
     "tags": {
       "value": {
@@ -646,36 +676,7 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
     ]
     enablePurgeProtection: false
     enableRbacAuthorization: true
-    keys: [
-      {
-        attributesExp: 1725109032
-        attributesNbf: 10000
-        name: 'keyName'
-        rotationPolicy: {
-          attributes: {
-            expiryTime: 'P2Y'
-          }
-          lifetimeActions: [
-            {
-              action: {
-                type: 'Rotate'
-              }
-              trigger: {
-                timeBeforeExpiry: 'P2M'
-              }
-            }
-            {
-              action: {
-                type: 'Notify'
-              }
-              trigger: {
-                timeBeforeExpiry: 'P30D'
-              }
-            }
-          ]
-        }
-      }
-    ]
+    keys: '<keys>'
     location: '<location>'
     lock: {
       kind: 'CanNotDelete'
@@ -752,36 +753,7 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
       "value": true
     },
     "keys": {
-      "value": [
-        {
-          "attributesExp": 1725109032,
-          "attributesNbf": 10000,
-          "name": "keyName",
-          "rotationPolicy": {
-            "attributes": {
-              "expiryTime": "P2Y"
-            },
-            "lifetimeActions": [
-              {
-                "action": {
-                  "type": "Rotate"
-                },
-                "trigger": {
-                  "timeBeforeExpiry": "P2M"
-                }
-              },
-              {
-                "action": {
-                  "type": "Notify"
-                },
-                "trigger": {
-                  "timeBeforeExpiry": "P30D"
-                }
-              }
-            ]
-          }
-        }
-      ]
+      "value": "<keys>"
     },
     "location": {
       "value": "<location>"
@@ -1105,7 +1077,6 @@ Name of the Key Vault. Must be globally unique.
 Service endpoint object information. For security reasons, it is recommended to set the DefaultAction Deny.
 - Required: No
 - Type: object
-- Default: `{object}`
 
 ### Parameter: `privateEndpoints`
 

--- a/avm/res/key-vault/vault/README.md
+++ b/avm/res/key-vault/vault/README.md
@@ -64,6 +64,7 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
     lock: '<lock>'
     networkAcls: '<networkAcls>'
     privateEndpoints: '<privateEndpoints>'
+    publicNetworkAccess: '<publicNetworkAccess>'
     roleAssignments: '<roleAssignments>'
     secrets: '<secrets>'
     tags: '<tags>'
@@ -109,6 +110,9 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
     },
     "privateEndpoints": {
       "value": "<privateEndpoints>"
+    },
+    "publicNetworkAccess": {
+      "value": "<publicNetworkAccess>"
     },
     "roleAssignments": {
       "value": "<roleAssignments>"
@@ -279,6 +283,7 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
         }
       }
     ]
+    publicNetworkAccess: '<publicNetworkAccess>'
     roleAssignments: [
       {
         principalId: '<principalId>'
@@ -484,6 +489,9 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
         }
       ]
     },
+    "publicNetworkAccess": {
+      "value": "<publicNetworkAccess>"
+    },
     "roleAssignments": {
       "value": [
         {
@@ -566,6 +574,7 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
         }
       }
     ]
+    publicNetworkAccess: '<publicNetworkAccess>'
     roleAssignments: '<roleAssignments>'
     secrets: '<secrets>'
     tags: {
@@ -627,6 +636,9 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
           }
         }
       ]
+    },
+    "publicNetworkAccess": {
+      "value": "<publicNetworkAccess>"
     },
     "roleAssignments": {
       "value": "<roleAssignments>"
@@ -695,6 +707,7 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
         subnetResourceId: '<subnetResourceId>'
       }
     ]
+    publicNetworkAccess: '<publicNetworkAccess>'
     roleAssignments: '<roleAssignments>'
     secrets: {
       secureList: [
@@ -780,6 +793,9 @@ module vault 'br/public:avm-res-keyvault-vault:1.0.0' = {
           "subnetResourceId": "<subnetResourceId>"
         }
       ]
+    },
+    "publicNetworkAccess": {
+      "value": "<publicNetworkAccess>"
     },
     "roleAssignments": {
       "value": "<roleAssignments>"
@@ -1251,8 +1267,7 @@ Optional. Tags to be applied on all resources/resource groups in this deployment
 Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set and networkAcls are not set.
 - Required: No
 - Type: string
-- Default: `''`
-- Allowed: `['', Disabled, Enabled]`
+- Allowed: `[Disabled, Enabled]`
 
 ### Parameter: `roleAssignments`
 

--- a/avm/res/key-vault/vault/main.bicep
+++ b/avm/res/key-vault/vault/main.bicep
@@ -54,7 +54,7 @@ param enablePurgeProtection bool = true
 param sku string = 'premium'
 
 @description('Optional. Service endpoint object information. For security reasons, it is recommended to set the DefaultAction Deny.')
-param networkAcls object = {}
+param networkAcls object?
 
 @description('Optional. Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set and networkAcls are not set.')
 @allowed([
@@ -156,7 +156,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
       name: sku
       family: 'A'
     }
-    networkAcls: !empty(networkAcls) ? {
+    networkAcls: null != networkAcls ? {
       bypass: networkAcls.?bypass
       defaultAction: networkAcls.?defaultAction
       virtualNetworkRules: networkAcls.?virtualNetworkRules ?? []

--- a/avm/res/key-vault/vault/main.bicep
+++ b/avm/res/key-vault/vault/main.bicep
@@ -58,11 +58,10 @@ param networkAcls object?
 
 @description('Optional. Whether or not public network access is allowed for this resource. For security reasons it should be disabled. If not specified, it will be disabled by default if private endpoints are set and networkAcls are not set.')
 @allowed([
-  ''
   'Enabled'
   'Disabled'
 ])
-param publicNetworkAccess string = ''
+param publicNetworkAccess string?
 
 @description('Optional. The lock settings of the service.')
 param lock lockType
@@ -162,7 +161,7 @@ resource keyVault 'Microsoft.KeyVault/vaults@2022-07-01' = {
       virtualNetworkRules: networkAcls.?virtualNetworkRules ?? []
       ipRules: networkAcls.?ipRules ?? []
     } : null
-    publicNetworkAccess: !empty(publicNetworkAccess) ? any(publicNetworkAccess) : (!empty(privateEndpoints) && empty(networkAcls) ? 'Disabled' : null)
+    publicNetworkAccess: null != publicNetworkAccess ? publicNetworkAccess : ((null != privateEndpoints && null != networkAcls) ? 'Disabled' : null)
   }
 }
 

--- a/avm/res/key-vault/vault/main.json
+++ b/avm/res/key-vault/vault/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.21.1.54444",
-      "templateHash": "3439795571102937161"
+      "templateHash": "1831434396807402641"
     },
     "name": "Key Vaults",
     "description": "This module deploys a Key Vault.",
@@ -465,7 +465,7 @@
     },
     "networkAcls": {
       "type": "object",
-      "defaultValue": {},
+      "nullable": true,
       "metadata": {
         "description": "Optional. Service endpoint object information. For security reasons, it is recommended to set the DefaultAction Deny."
       }
@@ -595,7 +595,7 @@
           "name": "[parameters('sku')]",
           "family": "A"
         },
-        "networkAcls": "[if(not(empty(parameters('networkAcls'))), createObject('bypass', tryGet(parameters('networkAcls'), 'bypass'), 'defaultAction', tryGet(parameters('networkAcls'), 'defaultAction'), 'virtualNetworkRules', coalesce(tryGet(parameters('networkAcls'), 'virtualNetworkRules'), createArray()), 'ipRules', coalesce(tryGet(parameters('networkAcls'), 'ipRules'), createArray())), null())]",
+        "networkAcls": "[if(not(equals(null(), parameters('networkAcls'))), createObject('bypass', tryGet(parameters('networkAcls'), 'bypass'), 'defaultAction', tryGet(parameters('networkAcls'), 'defaultAction'), 'virtualNetworkRules', coalesce(tryGet(parameters('networkAcls'), 'virtualNetworkRules'), createArray()), 'ipRules', coalesce(tryGet(parameters('networkAcls'), 'ipRules'), createArray())), null())]",
         "publicNetworkAccess": "[if(not(empty(parameters('publicNetworkAccess'))), parameters('publicNetworkAccess'), if(and(not(empty(parameters('privateEndpoints'))), empty(parameters('networkAcls'))), 'Disabled', null()))]"
       }
     },

--- a/avm/res/key-vault/vault/main.json
+++ b/avm/res/key-vault/vault/main.json
@@ -6,7 +6,7 @@
     "_generator": {
       "name": "bicep",
       "version": "0.21.1.54444",
-      "templateHash": "1831434396807402641"
+      "templateHash": "10388474954812360444"
     },
     "name": "Key Vaults",
     "description": "This module deploys a Key Vault.",
@@ -472,9 +472,8 @@
     },
     "publicNetworkAccess": {
       "type": "string",
-      "defaultValue": "",
+      "nullable": true,
       "allowedValues": [
-        "",
         "Enabled",
         "Disabled"
       ],
@@ -596,7 +595,7 @@
           "family": "A"
         },
         "networkAcls": "[if(not(equals(null(), parameters('networkAcls'))), createObject('bypass', tryGet(parameters('networkAcls'), 'bypass'), 'defaultAction', tryGet(parameters('networkAcls'), 'defaultAction'), 'virtualNetworkRules', coalesce(tryGet(parameters('networkAcls'), 'virtualNetworkRules'), createArray()), 'ipRules', coalesce(tryGet(parameters('networkAcls'), 'ipRules'), createArray())), null())]",
-        "publicNetworkAccess": "[if(not(empty(parameters('publicNetworkAccess'))), parameters('publicNetworkAccess'), if(and(not(empty(parameters('privateEndpoints'))), empty(parameters('networkAcls'))), 'Disabled', null()))]"
+        "publicNetworkAccess": "[if(not(equals(null(), parameters('publicNetworkAccess'))), parameters('publicNetworkAccess'), if(and(not(equals(null(), parameters('privateEndpoints'))), not(equals(null(), parameters('networkAcls')))), 'Disabled', null()))]"
       }
     },
     "keyVault_lock": {

--- a/avm/res/key-vault/vault/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/key-vault/vault/tests/e2e/defaults/main.test.bicep
@@ -47,13 +47,13 @@ module testDeployment '../../../main.bicep' = {
     // Only for testing purposes
     enablePurgeProtection: false
     // Workaround for PSRule
-    lock: {}
-    roleAssignments: []
-    diagnosticSettings: []
-    privateEndpoints: []
-    accessPolicies: []
-    secrets: {}
-    keys: []
-    tags: {}
+    lock: null
+    roleAssignments: null
+    diagnosticSettings: null
+    privateEndpoints: null
+    accessPolicies: null
+    secrets: null
+    keys: null
+    tags: null
   }
 }

--- a/avm/res/key-vault/vault/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/key-vault/vault/tests/e2e/defaults/main.test.bicep
@@ -56,5 +56,6 @@ module testDeployment '../../../main.bicep' = {
     keys: null
     tags: null
     networkAcls: null
+    publicNetworkAccess: null
   }
 }

--- a/avm/res/key-vault/vault/tests/e2e/defaults/main.test.bicep
+++ b/avm/res/key-vault/vault/tests/e2e/defaults/main.test.bicep
@@ -55,5 +55,6 @@ module testDeployment '../../../main.bicep' = {
     secrets: null
     keys: null
     tags: null
+    networkAcls: null
   }
 }

--- a/avm/res/key-vault/vault/tests/e2e/max/main.test.bicep
+++ b/avm/res/key-vault/vault/tests/e2e/max/main.test.bicep
@@ -233,5 +233,7 @@ module testDeployment '../../../main.bicep' = {
       Environment: 'Non-Prod'
       Role: 'DeploymentValidation'
     }
+    // Workaround for PSRule
+    publicNetworkAccess: null
   }
 }

--- a/avm/res/key-vault/vault/tests/e2e/private-endpoint/main.test.bicep
+++ b/avm/res/key-vault/vault/tests/e2e/private-endpoint/main.test.bicep
@@ -84,5 +84,13 @@ module testDeployment '../../../main.bicep' = {
     }
     // Only for testing purposes
     enablePurgeProtection: false
+    // Workaround for PSRule
+    keys: null
+    secrets: null
+    accessPolicies: null
+    networkAcls: null
+    roleAssignments: null
+    diagnosticSettings: null
+    lock: null
   }
 }

--- a/avm/res/key-vault/vault/tests/e2e/private-endpoint/main.test.bicep
+++ b/avm/res/key-vault/vault/tests/e2e/private-endpoint/main.test.bicep
@@ -92,5 +92,6 @@ module testDeployment '../../../main.bicep' = {
     roleAssignments: null
     diagnosticSettings: null
     lock: null
+    publicNetworkAccess: null
   }
 }

--- a/avm/res/key-vault/vault/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/key-vault/vault/tests/e2e/waf-aligned/main.test.bicep
@@ -142,7 +142,7 @@ module testDeployment '../../../main.bicep' = {
       Role: 'DeploymentValidation'
     }
     // Workaround for PSRule
-    roleAssignments: []
-    accessPolicies: []
+    roleAssignments: null
+    accessPolicies: null
   }
 }

--- a/avm/res/key-vault/vault/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/key-vault/vault/tests/e2e/waf-aligned/main.test.bicep
@@ -115,5 +115,6 @@ module testDeployment '../../../main.bicep' = {
     roleAssignments: null
     accessPolicies: null
     keys: null
+    publicNetworkAccess: null
   }
 }

--- a/avm/res/key-vault/vault/tests/e2e/waf-aligned/main.test.bicep
+++ b/avm/res/key-vault/vault/tests/e2e/waf-aligned/main.test.bicep
@@ -74,39 +74,7 @@ module testDeployment '../../../main.bicep' = {
         workspaceResourceId: diagnosticDependencies.outputs.logAnalyticsWorkspaceResourceId
       }
     ]
-    // Only for testing purposes
-    enablePurgeProtection: false
     enableRbacAuthorization: true
-    keys: [
-      {
-        attributesExp: 1725109032
-        attributesNbf: 10000
-        name: 'keyName'
-        rotationPolicy: {
-          attributes: {
-            expiryTime: 'P2Y'
-          }
-          lifetimeActions: [
-            {
-              trigger: {
-                timeBeforeExpiry: 'P2M'
-              }
-              action: {
-                type: 'Rotate'
-              }
-            }
-            {
-              trigger: {
-                timeBeforeExpiry: 'P30D'
-              }
-              action: {
-                type: 'Notify'
-              }
-            }
-          ]
-        }
-      }
-    ]
     lock: {
       kind: 'CanNotDelete'
       name: 'myCustomLockName'
@@ -141,8 +109,11 @@ module testDeployment '../../../main.bicep' = {
       Environment: 'Non-Prod'
       Role: 'DeploymentValidation'
     }
+    // Only for testing purposes
+    enablePurgeProtection: false
     // Workaround for PSRule
     roleAssignments: null
     accessPolicies: null
+    keys: null
   }
 }


### PR DESCRIPTION
## Description

Adjusted PSRule Workaround values to use `null` instead of an empty value. This works more consistently for all nullable values.

| Pipeline |
| - |
| [![avm.res.key-vault.vault](https://github.com/eriqua/bicep-registry-modules/actions/workflows/avm.res.key-vault.vault.yml/badge.svg?branch=users%2Falsehr%2FPSRuleValues)](https://github.com/eriqua/bicep-registry-modules/actions/workflows/avm.res.key-vault.vault.yml) |